### PR TITLE
fix: ignore directories when matching html files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = {
     const pattern = constants.PUBLISH_DIR + '/**/*.html';
 
     const files = await new Promise((resolve, reject) => {
-      glob(pattern, (err, files) => {
+      glob(pattern, { nodir: true }, (err, files) => {
         (err) ? reject(err) : resolve(files);
       });
     });


### PR DESCRIPTION
This plugin fails if there is a directory that matches the pattern.
For example Gatsby creates a `public/page-data/404.html` directory