### PR TITLE
Support ignore pattern from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To install, add the following lines to your **netlify.toml** file:
 ```toml
 [[plugins]]
 package = "netlify-plugin-amp-server-side-rendering"
+  [plugins.inputs]
+  ignorePattern = "public/admin/*"
 ```
 
 [1]: https://amp.dev/

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,1 +1,4 @@
 name: netlify-plugin-amp-server-side-rendering
+inputs:
+  - name: ignorePattern
+    description: Ignore pattern

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,19 @@ const fs = require('fs');
 const glob = require('glob');
 
 module.exports = {
-  onPostBuild: async ({ constants, utils }) => {
+  onPostBuild: async ({ inputs, constants, utils }) => {
     const pattern = constants.PUBLISH_DIR + '/**/*.html';
+    const options = {
+      nodir: true
+    }
+
+    if (inputs.ignorePattern) {
+      options.ignore = inputs.ignorePattern
+    }
 
     const files = await new Promise((resolve, reject) => {
-      glob(pattern, { nodir: true }, (err, files) => {
-        (err) ? reject(err) : resolve(files);
+      glob(pattern, options, (err, files) => {
+        (err) ? reject(err): resolve(files);
       });
     });
 


### PR DESCRIPTION
Support ignore pattern. Able use when setup Netlify CMS.